### PR TITLE
Remove pycrypto dependency

### DIFF
--- a/ffdemo/requirements/compiled.txt
+++ b/ffdemo/requirements/compiled.txt
@@ -11,4 +11,3 @@ MySQL-python==1.2.3
 # Deployments
 Fabric==1.0.1
 paramiko==2.0.9
-pycrypto==2.3


### PR DESCRIPTION
As it looks like pycrypto isn't actually used in this project, and pycrypto is unmaintained and has these vulnerabilities, this removes it from the requirements.

https://github.com/advisories/GHSA-cq27-v7xp-c356
https://github.com/advisories/GHSA-6528-wvf6-f6qg